### PR TITLE
Build mbedcrypto from other directory than mbedcrypto root dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,9 @@ option(BUILD_EC         "enable eckey, eckey_dh, ecdsa algorithms " OFF)
 
 #-----------------------------------------------------------------------------
 # common directories
-get_filename_component(PARENT_DIR ${CMAKE_SOURCE_DIR} DIRECTORY)
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
 set(DIR_XBIN     ${PARENT_DIR}/${PROJECT_NAME}.xbin${ARCH_TYPE})
-set(DIR_3RDPARTY ${CMAKE_SOURCE_DIR}/3rdparty)
+set(DIR_3RDPARTY ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${DIR_XBIN})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${DIR_XBIN})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${DIR_XBIN})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ option(BUILD_EC         "enable eckey, eckey_dh, ecdsa algorithms " OFF)
 
 #-----------------------------------------------------------------------------
 # common directories
-get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_BINARY_DIR} DIRECTORY)
 set(DIR_XBIN     ${PARENT_DIR}/${PROJECT_NAME}.xbin${ARCH_TYPE})
 set(DIR_3RDPARTY ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${DIR_XBIN})
@@ -58,9 +58,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${DIR_XBIN})
 set(INSTALL_DIR_INCLUDE include/mbedcrypto)
 set(INSTALL_DIR_LIBRARY lib)
 set(INSTALL_DIR_RUNTIME bin)
+set(MBEDCRYPTO_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 #-----------------------------------------------------------------------------
 # sub-projects
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 add_subdirectory(src)
 if(BUILD_TESTS)
     add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ readability, size, compiling and setup, … to name a few.
 ## disclaimer
 
 - implementing an easy-to-use, lightweight and portable `c++` library for
-cryptography are the main purpose of `mbedcrypto`.
+cryptography is the main purpose of `mbedcrypto`.
 - there are many more algorithms in cryptographic libraries, the focus of
 `mbedcrypto` is on the most important or widely used algorithms, tries to be
 simple and not to bloat your application.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,26 +46,26 @@ set(MBEDTLS_SRC
     )
 
 # header files to be exported by install
-set(DIR_MBEDCRYPTO_INCLUE "${CMAKE_SOURCE_DIR}/include/mbedcrypto")
+set(DIR_MBEDCRYPTO_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedcrypto")
 set(MBEDCRYPTO_HEADERS
-    ${DIR_MBEDCRYPTO_INCLUE}/configs.hpp
-    ${DIR_MBEDCRYPTO_INCLUE}/exception.hpp
-    ${DIR_MBEDCRYPTO_INCLUE}/types.hpp
-    ${DIR_MBEDCRYPTO_INCLUE}/tcodec.hpp
-    ${DIR_MBEDCRYPTO_INCLUE}/hash.hpp
-    ${DIR_MBEDCRYPTO_INCLUE}/cipher.hpp
-    ${DIR_MBEDCRYPTO_INCLUE}/rnd_generator.hpp
+    ${DIR_MBEDCRYPTO_INCLUDE}/configs.hpp
+    ${DIR_MBEDCRYPTO_INCLUDE}/exception.hpp
+    ${DIR_MBEDCRYPTO_INCLUDE}/types.hpp
+    ${DIR_MBEDCRYPTO_INCLUDE}/tcodec.hpp
+    ${DIR_MBEDCRYPTO_INCLUDE}/hash.hpp
+    ${DIR_MBEDCRYPTO_INCLUDE}/cipher.hpp
+    ${DIR_MBEDCRYPTO_INCLUDE}/rnd_generator.hpp
     )
 if(BUILD_PK_EXPORT OR BUILD_RSA_KEYGEN OR BUILD_EC)
     list(APPEND MBEDCRYPTO_HEADERS
-        ${DIR_MBEDCRYPTO_INCLUE}/mpi.hpp
-        ${DIR_MBEDCRYPTO_INCLUE}/pk.hpp
-        ${DIR_MBEDCRYPTO_INCLUE}/rsa.hpp
+        ${DIR_MBEDCRYPTO_INCLUDE}/mpi.hpp
+        ${DIR_MBEDCRYPTO_INCLUDE}/pk.hpp
+        ${DIR_MBEDCRYPTO_INCLUDE}/rsa.hpp
         )
 endif()
 if(BUILD_EC)
     list(APPEND MBEDCRYPTO_HEADERS
-        ${DIR_MBEDCRYPTO_INCLUE}/ecp.hpp
+        ${DIR_MBEDCRYPTO_INCLUDE}/ecp.hpp
         )
 endif()
 
@@ -188,7 +188,7 @@ target_compile_definitions(mbedtls_obj INTERFACE
 add_library(${PROJECT_NAME} ${MBEDCRYPTO_SRC})
 # modify this file to add/remove features and modules from mbedtls
 target_include_directories(${PROJECT_NAME} PUBLIC
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 set_target_properties(${PROJECT_NAME} PROPERTIES
     SOVERSION 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ set(MBEDTLS_SRC
     )
 
 # header files to be exported by install
-set(DIR_MBEDCRYPTO_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedcrypto")
+set(DIR_MBEDCRYPTO_INCLUDE "${MBEDCRYPTO_SOURCE_DIR}/include/mbedcrypto")
 set(MBEDCRYPTO_HEADERS
     ${DIR_MBEDCRYPTO_INCLUDE}/configs.hpp
     ${DIR_MBEDCRYPTO_INCLUDE}/exception.hpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,17 +1,16 @@
 project(mbedcrypto_tests)
 
 file(GLOB tests_src
-    ./tdd/**.hpp
-    ./tdd/**.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tdd/**.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tdd/**.cpp
     )
 add_executable(${PROJECT_NAME} ${tests_src})
 add_test(${PROJECT_NAME} ${DIR_XBIN}/${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} PRIVATE
-    ${CMAKE_SOURCE_DIR}
+    ${MBEDCRYPTO_SOURCE_DIR}
     ${DIR_3RDPARTY}/Catch/single_include
     )
 target_link_libraries(${PROJECT_NAME} mbedcrypto)
-install(TARGETS ${PROJECT_NAME} DESTINATION ${INSTALL_DIR_RUNTIME})
 
 if(BUILD_QT5_BIND)
     target_link_libraries(${PROJECT_NAME} Qt5::Core)
@@ -29,11 +28,11 @@ endif()
 # other test application
 OPTION(BUILD_TESTS_IDEA "build experimental and dirty test applications, you ain't gonna need it" OFF)
 if(BUILD_TESTS_IDEA)
-    add_executable(c_raii ./other/c_raii.cpp)
+    add_executable(c_raii ${CMAKE_CURRENT_SOURCE_DIR}/other/c_raii.cpp)
     target_link_libraries(c_raii mbedcrypto)
 
     if(BUILD_EC AND BUILD_PK_EXPORT)
-        add_executable(ec_keygen ./other/ec_keygen.cpp)
+        add_executable(ec_keygen ${CMAKE_CURRENT_SOURCE_DIR}/tests/other/ec_keygen.cpp)
         target_link_libraries(ec_keygen mbedcrypto)
     endif()
 


### PR DESCRIPTION
Made some changes in CMake to make the mbedcrypto library also 'buildable' from a different directory than the mbedcrypto root directory. This is useful when a CMake project, say `Project A`, uses the library. 

`Project A` has the mbedcrypto repo as a submodule in the directory `ProjectA/dep/mbedcrypto`.

The developer of `Project A` can add the library simply by adding this code to `ProjectA/CMakeLists.txt`:

```
file (GLOB MBEDCRYPTO "dep/mbedcrypto")
add_subdirectory(${MBEDCRYPTO})
target_link_libraries (ProjectA mbedcrypto)
```

From that point the library is linked to `Project A`.
The library can still be tested with `mbedcrypto_tests`. After calling `cmake` and `make` from the (unix) Terminal, the developer can test the library by executing:
```
dep/mbedcrypto.xbin64/mbedcrypto_tests
```
> The statement is executed from the `CMAKE_BINARY_DIRECTORY`.

If this pull request will be approved, I'm also planning to add a wiki page to the repo that describes how to link the mbedcrypto library to your own project as developer.