### PR TITLE
Update MbedcryptoPlatforms.cmake

### DIFF
--- a/cmake/MbedcryptoPlatforms.cmake
+++ b/cmake/MbedcryptoPlatforms.cmake
@@ -47,7 +47,7 @@ macro(target_prepare_build_flags tgt)
             set(${flag} "${${flag}}" CACHE STRING "msvc flags" FORCE)
         endforeach()
         target_compile_options(${tgt} PUBLIC
-            "$<$<CONFIG:Release>:${_src_opt}>"
+            "$<$<CONFIG:Release>:${_dst_opt}>"
             "$<$<CONFIG:Debug>:${_dst_opt}d>"
             )
     endif()


### PR DESCRIPTION
Fixed issue with building in Windows Release mode and using static/dynamic runtimes.